### PR TITLE
Because the current Bundler version (2.4.1) does not satisfy bundler …

### DIFF
--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_development_dependency "bundler", "~> 2.3.5"
+  spec.add_development_dependency "bundler", "~> 2.3.26"
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", ">= 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1"


### PR DESCRIPTION
…~> 2.3.5

  and Gemfile depends on bundler ~> 2.3.5,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running. Install the necessary version with `gem install bundler:2.3.26` and rerun bundler using `bundle _2.3.26_ install`
Error: Process completed with exit code 6.